### PR TITLE
Pom and Maven workflow updated

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@ on:
       - master
       - issue-*
 
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - issue-*

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <apache.poi.common.version>5.5.1</apache.poi.common.version>
         <apache.poi.ooxml.version>5.5.1</apache.poi.ooxml.version>
         <aspectj.version>1.9.25.1</aspectj.version>
-        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.6.0</maven-surefire-plugin.version>
+        <maven-compiler-plugin.version>3.16.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-enforcer.version>3.6.3</maven-enforcer.version>
         <java-release.version>17</java-release.version>
         <suite-xml>test-suite/testng.xml</suite-xml>


### PR DESCRIPTION
updated maven surefire version to 3.5.6 and compiler plugin version to 3.16.0, updated maven workflow to use the pull_request job instead of pull_request_target

Closes #216 